### PR TITLE
Fix MLOOKAT. The top-left 3x3 part was transposed.

### DIFF
--- a/ops.lisp
+++ b/ops.lisp
@@ -795,9 +795,9 @@
   (let* ((z (nvunit (v- eye target)))
          (x (nvunit (vc up z)))
          (y (vc z x)))
-    (mat (vx3 x) (vx3 y) (vx3 z) (- (v. x eye))
-         (vy3 x) (vy3 y) (vy3 z) (- (v. y eye))
-         (vz3 x) (vz3 y) (vz3 z) (- (v. z eye))
+    (mat (vx3 x) (vy3 x) (vz3 x) (- (v. x eye))
+         (vx3 y) (vy3 y) (vz3 y) (- (v. y eye))
+         (vx3 z) (vy3 z) (vz3 z) (- (v. z eye))
          #.(ensure-float 0) #.(ensure-float 0) #.(ensure-float 0) #.(ensure-float 1))))
 
 (declaim (ftype (function (real real real real real real) mat4) mfrustum))


### PR DESCRIPTION
I've compared both the algorithms and the resulting matrices that I got from `MLOOKAT` with MESA's and GLM's. The problem seems to be the upper-left 3x3 part of the matrix produced by `MLOOKAT`.

Here's `gluLookAt` from MESA. Note that MESA's implementation of matrices uses column-major indexing. Another thing to watch out for is that `forward` represents the -z axis of the view space (in constrast with your implementation where `z` represents the +z axis of the view space (which is easier to follow in my opinion)).

https://cgit.freedesktop.org/mesa/glu/tree/src/libutil/project.c#n108
```
gluLookAt(GLdouble eyex, GLdouble eyey, GLdouble eyez, GLdouble centerx,
	  GLdouble centery, GLdouble centerz, GLdouble upx, GLdouble upy,
	  GLdouble upz)
{
    float forward[3], side[3], up[3];
    GLfloat m[4][4];

    forward[0] = centerx - eyex;
    forward[1] = centery - eyey;
    forward[2] = centerz - eyez;

    up[0] = upx;
    up[1] = upy;
    up[2] = upz;

    normalize(forward);

    /* Side = forward x up */
    cross(forward, up, side);
    normalize(side);

    /* Recompute up as: up = side x forward */
    cross(side, forward, up);

    __gluMakeIdentityf(&m[0][0]);
    m[0][0] = side[0];
    m[1][0] = side[1];
    m[2][0] = side[2];

    m[0][1] = up[0];
    m[1][1] = up[1];
    m[2][1] = up[2];

    m[0][2] = -forward[0];
    m[1][2] = -forward[1];
    m[2][2] = -forward[2];

    glMultMatrixf(&m[0][0]);
    glTranslated(-eyex, -eyey, -eyez);
}
```

Here's the `lookAtRH` function that's used by GLM by default (since `lookAt` chooses either `lookAtLH` or `lookAtRH` based on the set up handedness, which is GLM_RIGHT_HANDED by default). GLM's implementation of matrices also uses column-major indexing and also calculates `f` so that it represents the -z axis of the view space.
 
https://github.com/g-truc/glm/blob/master/glm/gtc/matrix_transform.inl#L753
```
template <typename T, precision P>
GLM_FUNC_QUALIFIER tmat4x4<T, P> lookAtRH
(
    tvec3<T, P> const & eye,
    tvec3<T, P> const & center,
    tvec3<T, P> const & up
)
{
    tvec3<T, P> const f(normalize(center - eye));
    tvec3<T, P> const s(normalize(cross(f, up)));
    tvec3<T, P> const u(cross(s, f));

    tmat4x4<T, P> Result(1);
    Result[0][0] = s.x;
    Result[1][0] = s.y;
    Result[2][0] = s.z;
    Result[0][1] = u.x;
    Result[1][1] = u.y;
    Result[2][1] = u.z;
    Result[0][2] =-f.x;
    Result[1][2] =-f.y;
    Result[2][2] =-f.z;
    Result[3][0] =-dot(s, eye);
    Result[3][1] =-dot(u, eye);
    Result[3][2] = dot(f, eye);
    return Result;
}
```