### PR TITLE
Fix to expand symbol I correctly

### DIFF
--- a/struct.lisp
+++ b/struct.lisp
@@ -72,7 +72,7 @@
          (aref (,marr mat) i)))
      
      (defsetf* ,mcref (mat y x &environment env) (value)
-       `(let ((#1=(gensym "I") (+ (* ,y ,,size) ,x)))
+       `(let ((#1=#.(gensym "I") (+ (* ,y ,,size) ,x)))
           #+lispworks
           (unless (< -1 i (length (,',marr 'mat)))
             (error "~d,~d is out of bounds for ~a" ,y ,x ,mat))


### PR DESCRIPTION
I fixed the macro for running below code.
```lisp
(defvar m (mat 1 2 3 4))
(setf (mcref m 0 0) 2)
```